### PR TITLE
Backport sc16is7xx: always write state when configuring GPIO as an output

### DIFF
--- a/drivers/tty/serial/sc16is7xx.c
+++ b/drivers/tty/serial/sc16is7xx.c
@@ -1120,9 +1120,13 @@ static int sc16is7xx_gpio_direction_output(struct gpio_chip *chip,
 	struct sc16is7xx_port *s = container_of(chip, struct sc16is7xx_port,
 						gpio);
 	struct uart_port *port = &s->p[0].port;
+	u8 state = sc16is7xx_port_read(port, SC16IS7XX_IOSTATE_REG);
 
-	sc16is7xx_port_update(port, SC16IS7XX_IOSTATE_REG, BIT(offset),
-			      val ? BIT(offset) : 0);
+	if (val)
+		state |= BIT(offset);
+	else
+		state &= ~BIT(offset);
+	sc16is7xx_port_write(port, SC16IS7XX_IOSTATE_REG, state);
 	sc16is7xx_port_update(port, SC16IS7XX_IODIR_REG, BIT(offset),
 			      BIT(offset));
 


### PR DESCRIPTION
The regmap_update first reads the IOState register and then triggers
a write if needed. However, GPIOS might be configured as an input so
 the read to IOState on this GPIO is the current state which might
be random.

Signed-off-by: Francois Berder <Francois.Berder@imgtec.com>
Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
This fixes CreatorDev/openwrt#253